### PR TITLE
Add Fluent Bit and OTEL collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ This repository contains Flux manifests for the demo Kubernetes cluster.
 The cluster deploys the `kbot` application (see `clusters/demo/kbot-hr.yml`) alongside a monitoring stack consisting of:
 
 - OpenTelemetry Operator
+- OpenTelemetry Collector
+- Fluent Bit (forwarding logs to the collector)
 - Prometheus
-- Fluent Bit
 - Grafana Loki
 - Grafana
 
-Helm repositories and releases for these tools are defined under `clusters/demo/`.
+Helm repositories and releases for these tools are defined under `clusters/demo/otel/`.

--- a/clusters/demo/otel/fluent-bit-hr.yml
+++ b/clusters/demo/otel/fluent-bit-hr.yml
@@ -1,0 +1,23 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: fluent-bit
+  namespace: demo
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: fluent-bit
+      version: 0.49.1
+      sourceRef:
+        kind: HelmRepository
+        name: fluent-bit
+        namespace: demo
+  values:
+    outputs: |
+      [OUTPUT]
+          Name opentelemetry
+          Match *
+          Host collector.demo.svc.cluster.local
+          Port 4317
+          Mode grpc

--- a/clusters/demo/otel/fluent-bit-repo.yml
+++ b/clusters/demo/otel/fluent-bit-repo.yml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: fluent-bit
+  namespace: demo
+spec:
+  interval: 1h
+  url: https://fluent.github.io/helm-charts

--- a/clusters/demo/otel/otel-collector-hr.yml
+++ b/clusters/demo/otel/otel-collector-hr.yml
@@ -1,0 +1,18 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: collector
+  namespace: demo
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: opentelemetry-collector
+      version: 0.127.1
+      sourceRef:
+        kind: HelmRepository
+        name: open-telemetry
+        namespace: demo
+  values:
+    mode: deployment
+    fullnameOverride: collector

--- a/clusters/demo/otel/otel-repo.yml
+++ b/clusters/demo/otel/otel-repo.yml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: open-telemetry
+  namespace: demo
+spec:
+  interval: 1h
+  url: https://open-telemetry.github.io/opentelemetry-helm-charts


### PR DESCRIPTION
## Summary
- organize telemetry resources under `clusters/demo/otel`
- update README path for monitoring stack

## Testing
- *no tests run*

------
https://chatgpt.com/codex/tasks/task_e_685aadbc5b5c832d89e9147b00ef4369