### PR TITLE
Add monitoring stack charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The cluster deploys the `kbot` application (see `clusters/demo/kbot-hr.yml`) alo
 - Grafana
 
 Helm repositories and releases for these tools are defined under `clusters/demo/otel/`.
+Additional Helm releases for Loki, Prometheus and Grafana live in the same directory.
 The `clusters/demo` directory now includes a `kustomization.yaml` that pulls in
 all manifests from this `otel` folder so they are part of the cluster build.
 

--- a/clusters/demo/otel/grafana-hr.yml
+++ b/clusters/demo/otel/grafana-hr.yml
@@ -1,0 +1,16 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: grafana
+  namespace: demo
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: grafana
+      sourceRef:
+        kind: HelmRepository
+        name: grafana
+        namespace: demo
+  values:
+    adminPassword: admin

--- a/clusters/demo/otel/grafana-repo.yml
+++ b/clusters/demo/otel/grafana-repo.yml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: grafana
+  namespace: demo
+spec:
+  interval: 1h
+  url: https://grafana.github.io/helm-charts

--- a/clusters/demo/otel/kustomization.yaml
+++ b/clusters/demo/otel/kustomization.yaml
@@ -5,3 +5,8 @@ resources:
   - fluent-bit-hr.yml
   - otel-repo.yml
   - otel-collector-hr.yml
+  - grafana-repo.yml
+  - grafana-hr.yml
+  - prometheus-repo.yml
+  - prometheus-hr.yml
+  - loki-hr.yml

--- a/clusters/demo/otel/loki-hr.yml
+++ b/clusters/demo/otel/loki-hr.yml
@@ -1,0 +1,16 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: loki
+  namespace: demo
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: loki
+      sourceRef:
+        kind: HelmRepository
+        name: grafana
+        namespace: demo
+  values:
+    fullnameOverride: loki

--- a/clusters/demo/otel/otel-collector-hr.yml
+++ b/clusters/demo/otel/otel-collector-hr.yml
@@ -16,3 +16,33 @@ spec:
   values:
     mode: deployment
     fullnameOverride: collector
+    image:
+      repository: otel/opentelemetry-collector-contrib
+      tag: 0.128.0
+    config:
+      receivers:
+        otlp:
+          protocols:
+            grpc: {}
+            http:
+              endpoint: "0.0.0.0:3030"
+
+      exporters:
+        debug:
+          verbosity: normal
+        loki:
+          endpoint: http://loki:3100/loki/api/v1/push
+        prometheus:
+          endpoint: "0.0.0.0:8889"
+
+      service:
+        pipelines:
+          logs:
+            receivers: [otlp]
+            exporters: [loki]
+          traces:
+            receivers: [otlp]
+            exporters: [debug]
+          metrics:
+            receivers: [otlp]
+            exporters: [debug, prometheus]

--- a/clusters/demo/otel/prometheus-hr.yml
+++ b/clusters/demo/otel/prometheus-hr.yml
@@ -1,0 +1,16 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: prometheus
+  namespace: demo
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: prometheus
+      sourceRef:
+        kind: HelmRepository
+        name: prometheus-community
+        namespace: demo
+  values:
+    fullnameOverride: prometheus

--- a/clusters/demo/otel/prometheus-repo.yml
+++ b/clusters/demo/otel/prometheus-repo.yml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: prometheus-community
+  namespace: demo
+spec:
+  interval: 1h
+  url: https://prometheus-community.github.io/helm-charts


### PR DESCRIPTION
## Summary
- set up Helm repos for Grafana and Prometheus
- deploy Grafana, Loki and Prometheus with HelmReleases
- include the new releases in the otel kustomization
- document monitoring stack additions

## Testing
- `kustomize build clusters/demo`

------
https://chatgpt.com/codex/tasks/task_e_685bae38bb00832d9bd3ed597c0d561a